### PR TITLE
新增NPOI对工作簿对象工作表对象的相关操作

### DIFF
--- a/EasyTool.NPOI/EasyTool.NPOI.csproj
+++ b/EasyTool.NPOI/EasyTool.NPOI.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.1;.net6.0</TargetFrameworks>
+		<Nullable>enable</Nullable>
+		<LangVersion>11</LangVersion>
+		<Authors>Hang</Authors>
+		<Description>
+			依赖于NPOI 2.6.2
+			支持通过文件地址或者流的方式读取Excel文件获取工作簿对象IWorkbook,
+			通过IWorkbook工作簿对象可以转化成Dataset对象
+			通过ISheet工作表对象可以转化成DataTable对象和List对象
+			以下是一些示例:
+			获取数据集对象：
+			var dateSet = NPOIUtil.OpenWorkbook(path).ConvertToDataSet();
+			var dateSet = NPOIUtil.ConvertToDataSet(path);
+			获取工作表对象：
+			var sheet = NPOIUtil.OpenWorkbook(path).GetSheetAt(0);
+			获取单表数据对象：
+			var dataTable = NPOIUtil.OpenWorkbook(path).GetSheetAt(0).ConvertToDataTable();
+			List《T》 dataList = NPOIUtil.OpenWorkbook(path).GetSheetAt(0).ConvertToList《List《T》》();
+			从流读取工作簿对象(从流读取需要指定文件类型，缺省值为XLSX)：
+			var workbook = NPOIUtil.OpenWorkbook(stream,ExcelWorkbookType.XLS);
+		</Description>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="NPOI" Version="2.6.2" />
+	</ItemGroup>
+
+</Project>

--- a/EasyTool.NPOI/ExcelWorkbookType.cs
+++ b/EasyTool.NPOI/ExcelWorkbookType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EasyTool.NPOI;
+
+public enum ExcelWorkbookType
+{
+    /// <summary>
+    /// xls类型适用于Office2003及以下版本
+    /// </summary>
+    XLS,
+    /// <summary>
+    /// xlsx类型适用于Office2007及以上版本
+    /// </summary>
+    XLSX
+}

--- a/EasyTool.NPOI/NPOIUtil.cs
+++ b/EasyTool.NPOI/NPOIUtil.cs
@@ -1,0 +1,286 @@
+﻿using NPOI.HSSF.UserModel;
+using NPOI.POIFS.NIO;
+using NPOI.SS.Formula.Functions;
+using NPOI.SS.UserModel;
+using NPOI.Util.ArrayExtensions;
+using NPOI.XSSF.UserModel;
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace EasyTool.NPOI;
+
+public static class NPOIUtil
+{
+    /// <summary>
+    /// 输入文件绝对路径，获取工作簿对象
+    /// HHSWorkbook:适用于.xls文件; XSSFWorkbook:适用于.xlsx文件
+    /// </summary>
+    /// <param name="path">绝对路径</param>
+    /// <returns>IWorkbook</returns>
+    public static IWorkbook OpenWorkbook(string path)
+    {
+        if (path == null || !File.Exists(path))
+            throw new Exception($"路径{path}不存在");
+        using var stream = File.OpenRead(path);
+        return Path.GetExtension(path) == ".xls"
+            ? new HSSFWorkbook(stream)
+            : new XSSFWorkbook(stream);
+    }
+    /// <summary>
+    /// 从流读取工作簿，自动判断类型或者显示指定类型
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="fileExtension">
+    /// null or 缺省:适用于不明确的文件类型
+    /// xls:适用于.xls文件
+    /// xlsx:适用于.xlsx文件
+    /// </param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception> 
+    
+    public static IWorkbook OpenWorkbookFromStream(Stream stream, ExcelWorkbookType excelType =ExcelWorkbookType.XLSX)
+    {
+        if (stream == null)
+            throw new Exception("流不能为空");
+        return excelType switch
+        {
+            ExcelWorkbookType.XLS => new HSSFWorkbook(stream),
+            ExcelWorkbookType.XLSX => new XSSFWorkbook(stream),
+            _ => throw new Exception("不支持的格式类型,请选择")
+        };
+    }
+    /// <summary>
+    /// 把IWorkbook类型的对象转换成DataSet
+    /// </summary>
+    /// <param name="workbooks"></param>
+    /// <returns></returns>
+    public static DataSet? ConvertToDataSet(this IWorkbook workbooks)
+    {
+        if (workbooks.NumberOfSheets == 0)
+            return new DataSet("EmptyDataSet");
+        var dataSet = new DataSet(workbooks.GetSheetName(0));
+        for (var i = 0; i < workbooks.NumberOfSheets; i++)
+        {
+            var sheet = workbooks.GetSheetAt(i);
+            var table = new DataTable(sheet.SheetName);
+            var headerRow = sheet.GetRow(0);
+            if (headerRow == null)
+            {
+                dataSet.Tables.Add(table);
+                continue;
+            }
+            var cellCount = headerRow.LastCellNum;
+            for (var j = headerRow.FirstCellNum; j < cellCount; j++)
+            {
+                var column = new DataColumn(headerRow.GetCell(j).StringCellValue);
+                table.Columns.Add(column);
+            }
+            var rowCount = sheet.LastRowNum;
+            for (var k = sheet.FirstRowNum +1; k <= rowCount; k++)
+            {
+                var row = sheet.GetRow(k);
+                var dataRow = table.NewRow();
+                for (var m = 0; m < cellCount; m++)
+                {
+                    dataRow[m] = row.GetCell(m).ToString();
+                }
+                table.Rows.Add(dataRow);
+            }
+            dataSet.Tables.Add(table);
+        }
+        return dataSet;
+    }
+    /// <summary>
+    /// 输入文件绝对路径,获取解析后的DataSet对象
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public static DataSet? ConvertToDataSet(string path)
+    {
+        var wookbook = OpenWorkbook(path) ?? throw new Exception("路径");
+        return ConvertToDataSet(wookbook);
+    }
+    /// <summary>
+    /// 适用单表，把IWorkbook类型的对象转换成List
+    /// </summary>
+    /// <typeparam name="T">目标泛型</typeparam>
+    /// <param name="wookbook"></param>
+    /// <example> IWorkbook workbook;workbook.GetSheetAt(0).ToList<T>();</example>
+    /// <returns></returns>
+    public static List<T> ConvertToList<T>(this ISheet sheet) where T : new()
+    {
+        List<T> list = new();
+        var headerRow = sheet.GetRow(0);
+        if (headerRow == null)
+            return list;
+        var cellCount = headerRow.LastCellNum;
+        var rowCount = sheet.LastRowNum;
+        for (var k = sheet.FirstRowNum + 1; k < rowCount; k++)
+        {
+            var row = sheet.GetRow(k);
+            T t = new();
+            for (var m = row.FirstCellNum; m < cellCount; m++)
+            {
+                var cell = row.GetCell(m);
+                var value = cell?.ToString();
+                if (value == null)
+                    continue;
+                var property = t.GetType().GetProperty(headerRow.GetCell(m).StringCellValue);
+                if (property == null)
+                    continue;
+                property.SetValue(t, value, null);
+            }
+            list.Add(t);
+        }
+        return list;
+    }
+    /// <summary>
+    /// 根据工作表对象返回DataTable
+    /// </summary>
+    /// <param name="sheet">工作表对象</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">不应传入一个空的工作表对象</exception>
+    public static DataTable ConvertToDatatable(this ISheet sheet)
+    {
+        if (sheet == null)
+            throw new ArgumentNullException(nameof(sheet));
+        DataTable dataTable = new(sheet.SheetName);
+        var columns= new List<DataColumn>();
+        var headerRow = sheet.GetRow(0);
+        if (headerRow == null)
+            return dataTable;
+        headerRow.Cells.ForEach(cell =>
+        {
+            var column = new DataColumn(cell.StringCellValue);
+            columns.Add(column);
+        });
+        dataTable.Columns.AddRange(columns.ToArray());
+        var rowCount = sheet.LastRowNum;
+        for (var k = sheet.FirstRowNum + 1; k < rowCount; k++)
+        {
+            var row = sheet.GetRow(k);
+            var dataRow = dataTable.NewRow();
+            for (var m = 0; m < columns.Count; m++)
+            {
+                dataRow[m] = row.GetCell(m).ToString();
+            }
+            dataTable.Rows.Add(dataRow);
+        }
+        return dataTable;
+    }
+    /// <summary>
+    /// 导出到Excel
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="dataSource">IEnumerable<T></param>
+    /// <param name="path">文件夹路径</param>
+    /// <param name="workbookType">工作簿类型</param>
+    /// <param name="filename">文件名称</param>
+
+    public static bool ExportToExcel<T>(IEnumerable<T> dataSource,string path, out string message, ExcelWorkbookType workbookType =ExcelWorkbookType.XLSX,string? filename=null)
+    {
+        bool result = true;
+        message = "导出成功";
+        try
+        {
+            IWorkbook workbook = workbookType.Equals(ExcelWorkbookType.XLSX) ? new XSSFWorkbook() : new HSSFWorkbook();
+            T t = dataSource.FirstOrDefault();
+            filename ??= typeof(T).Name;
+            ISheet sheet = workbook.CreateSheet(filename);
+            IRow headerRow = sheet.CreateRow(0);
+            var props = typeof(T).GetProperties().Where(x => x.PropertyType.IsPublic);
+            int count = props.Count(); //T类型公开属性的数量
+            for (int i = 0; i < count; i++)
+            {
+                headerRow.CreateCell(i).SetCellValue(props.ElementAt(i).Name);
+            }
+            var length = dataSource.Count();//数据源的行数
+            for (int i = 0; i < length; i++)
+            {
+                IRow row = sheet.CreateRow(i + 1);
+                for (int j = 0; j < count; j++)
+                {
+                    row.CreateCell(j).SetCellValue(props.ElementAt(j).GetValue(dataSource.ElementAt(i)).ToString());
+                }
+            }
+            string filePath = $"{path}{filename}";
+            string extension = workbookType.Equals(ExcelWorkbookType.XLSX) ? ".xlsx" : ".xls";
+            int num = 1;
+            while (File.Exists(filePath + extension))
+            {
+                filePath = $"{path}{filename}({num})";
+                num++;
+            }
+            using var fs = new FileStream(filePath + extension, FileMode.Create, FileAccess.Write);
+            workbook.Write(fs);
+        }
+        catch (Exception e)
+        {
+            result = false;
+            message = $"导出失败：{e.Message}";
+        }
+        return result;
+        
+    }
+    /// <summary>
+    /// DataTable导出到Excel
+    /// </summary>
+    /// <param name="dataTable">数据源</param>
+    /// <param name="path">保存路径</param>
+    /// <param name="workbookType">工作簿类型</param>
+    /// <param name="filename">文件名</param>
+    public static bool ExportToExcel(this DataTable dataTable, string path, out string message, ExcelWorkbookType workbookType = ExcelWorkbookType.XLSX, string? filename = null)
+    {
+        bool result = true;
+        message = string.Empty;
+        try
+        {
+            IWorkbook workbook = workbookType.Equals(ExcelWorkbookType.XLSX) ? new XSSFWorkbook() : new HSSFWorkbook();
+            filename = string.IsNullOrEmpty(filename)
+                ? string.IsNullOrEmpty(dataTable.TableName)
+                    ? DateTime.Now.ToString("yyyyMMddHHmmss")
+                    : dataTable.TableName
+                : filename;
+            ISheet sheet = workbook.CreateSheet(filename);
+            IRow headerRow = sheet.CreateRow(0);
+            ;
+            for (int i = 0; i < dataTable.Columns.Count; i++)
+            {
+                headerRow.CreateCell(i).SetCellValue(dataTable.Columns[i].ColumnName);
+            }
+            for (int i = 0; i < dataTable.Rows.Count; i++)
+            {
+                IRow row = sheet.CreateRow(i + 1);
+                for (int j = 0; j < dataTable.Columns.Count; j++)
+                {
+                    row.CreateCell(j).SetCellValue(dataTable.Rows[i][j].ToString());
+                }
+            }
+            string filePath = $"{path}{filename}";
+            string extension = workbookType.Equals(ExcelWorkbookType.XLSX) ? ".xlsx" : ".xls";
+            int num = 1;
+            while (File.Exists(filePath + extension))
+            {
+                filePath = $"{path}{filename}({num})";
+                num++;
+            }
+            using var fs = new FileStream(filePath + extension, FileMode.Create, FileAccess.Write);
+
+            workbook.Write(fs);
+        }
+        catch (Exception e)
+        {
+            result = false;
+            message = e.Message;
+        }
+        return result;
+        
+    }
+}

--- a/EasyTool.NPOITests/EasyTool.NPOITests.csproj
+++ b/EasyTool.NPOITests/EasyTool.NPOITests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EasyTool.NPOI\EasyTool.NPOI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EasyTool.NPOITests/NPOIUtilTests.cs
+++ b/EasyTool.NPOITests/NPOIUtilTests.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EasyTool.NPOI;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NPOI.SS.UserModel;
+using System.Data;
+using System.Text.Json;
+
+namespace EasyTool.NPOITests;
+
+[TestClass()]
+public class NPOIUtilTests
+{
+    string path = @"D:\TempClass.xlsx";
+    List<TempClass> dataList = new List<TempClass>()
+    {
+        new TempClass()
+        {
+            Name = "张三",
+            Age = 1,
+            Birthday = DateTime.Now
+        },
+        new TempClass()
+        {
+            Name = "李四",
+            Age = 11,
+            Birthday = DateTime.Now.AddDays(1)
+        },
+        new TempClass()
+        {
+            Name = "王五",
+            Age = 23,
+            Birthday = DateTime.Now.AddMonths(1)
+        }
+    };
+    DataTable dataTable;
+    public NPOIUtilTests()
+    {
+        dataTable = new DataTable();
+        dataTable.Columns.AddRange(new DataColumn[]
+        {
+            new DataColumn("Name",typeof(string)),
+            new DataColumn("Age",typeof(int)),
+            new DataColumn("Birthday",typeof(DateTime))
+        });
+        foreach (var item in dataList)
+        {
+            DataRow dataRow = dataTable.NewRow();
+            dataRow["Name"] = item.Name;
+            dataRow["Age"] = item.Age;
+            dataRow["Birthday"] = item.Birthday;
+            dataTable.Rows.Add(dataRow);
+        }
+    }
+    [TestMethod]
+    public void Test_ExportToExcel()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+    }
+    [TestMethod]
+    public void Test_ExportToExcelFromDatatable()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+
+    }
+    [TestMethod]
+    public void Test_OpenWorkbookFromPath()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        Console.WriteLine(workbook.GetSheetName(0));
+        Assert.IsNotNull(workbook);
+    }
+    [TestMethod]
+    public void Test_OpenWorkbookFromStream()
+    {
+        using Stream stream = File.OpenRead(path);
+        var workbook = NPOIUtil.OpenWorkbookFromStream(stream, ExcelWorkbookType.XLSX);
+        Console.WriteLine(workbook.GetSheetName(0));
+        Assert.IsNotNull(workbook);
+    }
+    [TestMethod]
+    public void Test_ConvertToDataSet()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        var dataSet = workbook.ConvertToDataSet();
+        Console.WriteLine(dataSet?.DataSetName);
+        Assert.IsNotNull(dataSet);
+    }
+    [TestMethod]
+    public void Test_ConvertToDataTable()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        var dataTable = workbook.GetSheetAt(0).ConvertToDatatable();
+        Console.WriteLine(dataTable.TableName);
+        Assert.IsNotNull(dataTable);
+    }
+    [TestMethod]
+    public void Test_ConvertToList<T>() where T : new()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        List<T> dataList = workbook.GetSheetAt(0).ConvertToList<T>();
+        Console.WriteLine(JsonSerializer.Serialize(dataList));
+        Assert.IsNotNull(dataList);
+    }
+
+}
+class TempClass
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+    public DateTime Birthday { get; set; }
+}

--- a/EasyTool.NPOITests/NPOIUtilTests.cs
+++ b/EasyTool.NPOITests/NPOIUtilTests.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EasyTool.NPOI;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NPOI.SS.UserModel;
+using System.Data;
+using System.Text.Json;
+
+namespace EasyTool.NPOITests;
+
+[TestClass()]
+public class NPOIUtilTests
+{
+    string path = @"D:\TempClass.xlsx";
+    List<TempClass> dataList = new List<TempClass>()
+    {
+        new TempClass()
+        {
+            Name = "张三",
+            Age = 1,
+            Birthday = DateTime.Now
+        },
+        new TempClass()
+        {
+            Name = "李四",
+            Age = 11,
+            Birthday = DateTime.Now.AddDays(1)
+        },
+        new TempClass()
+        {
+            Name = "王五",
+            Age = 23,
+            Birthday = DateTime.Now.AddMonths(1)
+        }
+    };
+    DataTable dataTable;
+    public NPOIUtilTests()
+    {
+        dataTable = new DataTable();
+        dataTable.Columns.AddRange(new DataColumn[]
+        {
+            new DataColumn("Name",typeof(string)),
+            new DataColumn("Age",typeof(int)),
+            new DataColumn("Birthday",typeof(DateTime))
+        });
+        foreach (var item in dataList)
+        {
+            DataRow dataRow = dataTable.NewRow();
+            dataRow["Name"] = item.Name;
+            dataRow["Age"] = item.Age;
+            dataRow["Birthday"] = item.Birthday;
+            dataTable.Rows.Add(dataRow);
+        }
+    }
+    [TestMethod]
+    public void Test_OpenWorkbookFromPath()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        Console.WriteLine(workbook.GetSheetName(0));
+        Assert.IsNotNull(workbook);
+    }
+    [TestMethod]
+    public void Test_OpenWorkbookFromStream()
+    {
+        using Stream stream = File.OpenRead(path);
+        var workbook = NPOIUtil.OpenWorkbookFromStream(stream, ExcelWorkbookType.XLSX);
+        Console.WriteLine(workbook.GetSheetName(0));
+        Assert.IsNotNull(workbook);
+    }
+    [TestMethod]
+    public void Test_ConvertToDataSet()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        var dataSet = workbook.ConvertToDataSet();
+        Console.WriteLine(dataSet?.DataSetName);
+        Assert.IsNotNull(dataSet);
+    }
+    [TestMethod]
+    public void Test_ConvertToDataTable()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        var dataTable = workbook.GetSheetAt(0).ConvertToDatatable();
+        Console.WriteLine(dataTable.TableName);
+        Assert.IsNotNull(dataTable);
+    }
+    [TestMethod]
+    public void Test_ConvertToList<T>() where T : new()
+    {
+        var workbook = NPOIUtil.OpenWorkbook(path);
+        List<T> dataList = workbook.GetSheetAt(0).ConvertToList<T>();
+        Console.WriteLine(JsonSerializer.Serialize(dataList));
+        Assert.IsNotNull(dataList);
+    }
+    [TestMethod]
+    public void Test_ExportToExcel()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+    }
+    [TestMethod]
+    public void Test_ExportToExcelFromDatatable()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+
+    }
+}
+class TempClass
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+    public DateTime Birthday { get; set; }
+}

--- a/EasyTool.NPOITests/NPOIUtilTests.cs
+++ b/EasyTool.NPOITests/NPOIUtilTests.cs
@@ -55,6 +55,7 @@ public class NPOIUtilTests
         }
     }
     [TestMethod]
+<<<<<<< HEAD
     public void Test_ExportToExcel()
     {
         bool res = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg);
@@ -70,6 +71,8 @@ public class NPOIUtilTests
 
     }
     [TestMethod]
+=======
+>>>>>>> f55b561c4c86f7ff74b0740f770f6c5810f28ed8
     public void Test_OpenWorkbookFromPath()
     {
         var workbook = NPOIUtil.OpenWorkbook(path);
@@ -108,7 +111,25 @@ public class NPOIUtilTests
         Console.WriteLine(JsonSerializer.Serialize(dataList));
         Assert.IsNotNull(dataList);
     }
+<<<<<<< HEAD
 
+=======
+    [TestMethod]
+    public void Test_ExportToExcel()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataList, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+    }
+    [TestMethod]
+    public void Test_ExportToExcelFromDatatable()
+    {
+        bool res = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg);
+        bool res2 = NPOIUtil.ExportToExcel(dataTable, "D:\\", out string msg2, ExcelWorkbookType.XLS);
+        Assert.IsTrue(res && res2);
+
+    }
+>>>>>>> f55b561c4c86f7ff74b0740f770f6c5810f28ed8
 }
 class TempClass
 {

--- a/EasyTool.sln
+++ b/EasyTool.sln
@@ -13,7 +13,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.EmitMapperTests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.Web", "EasyTool.Web\EasyTool.Web.csproj", "{578D6FC8-C937-4FAE-B776-9E52043BA8E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyTool.WebTests", "EasyTool.WebTests\EasyTool.WebTests.csproj", "{E033014B-67D0-4B42-8507-B90ACE0BD059}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.WebTests", "EasyTool.WebTests\EasyTool.WebTests.csproj", "{E033014B-67D0-4B42-8507-B90ACE0BD059}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOI", "EasyTool.NPOI\EasyTool.NPOI.csproj", "{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOITests", "EasyTool.NPOITests\EasyTool.NPOITests.csproj", "{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/EasyTool.sln
+++ b/EasyTool.sln
@@ -15,9 +15,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.Web", "EasyTool.We
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.WebTests", "EasyTool.WebTests\EasyTool.WebTests.csproj", "{E033014B-67D0-4B42-8507-B90ACE0BD059}"
 EndProject
+<<<<<<< HEAD
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOI", "EasyTool.NPOI\EasyTool.NPOI.csproj", "{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOITests", "EasyTool.NPOITests\EasyTool.NPOITests.csproj", "{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}"
+=======
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOI", "EasyTool.NPOI\EasyTool.NPOI.csproj", "{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOITests", "EasyTool.NPOITests\EasyTool.NPOITests.csproj", "{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}"
+>>>>>>> f55b561c4c86f7ff74b0740f770f6c5810f28ed8
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +55,7 @@ Global
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.Build.0 = Release|Any CPU
+<<<<<<< HEAD
 		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -57,6 +64,16 @@ Global
 		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Release|Any CPU.Build.0 = Release|Any CPU
+=======
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9851A3CE-3B15-47A9-AE12-D35E046AE8CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC34ADB2-9F6F-4D6B-A1C3-A072D18CC0E4}.Release|Any CPU.Build.0 = Release|Any CPU
+>>>>>>> f55b561c4c86f7ff74b0740f770f6c5810f28ed8
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/EasyTool.sln
+++ b/EasyTool.sln
@@ -13,7 +13,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.EmitMapperTests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.Web", "EasyTool.Web\EasyTool.Web.csproj", "{578D6FC8-C937-4FAE-B776-9E52043BA8E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyTool.WebTests", "EasyTool.WebTests\EasyTool.WebTests.csproj", "{E033014B-67D0-4B42-8507-B90ACE0BD059}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.WebTests", "EasyTool.WebTests\EasyTool.WebTests.csproj", "{E033014B-67D0-4B42-8507-B90ACE0BD059}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOI", "EasyTool.NPOI\EasyTool.NPOI.csproj", "{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyTool.NPOITests", "EasyTool.NPOITests\EasyTool.NPOITests.csproj", "{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E033014B-67D0-4B42-8507-B90ACE0BD059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE4A694E-0981-4B89-A0F6-4AD96CA0A9B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D57CCAA-DEB3-4C89-BC8B-F14560F6460E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,13 +1,55 @@
-# easytool
-An open source C# tool to make .NET easy
+<h1 align="center"> EasyTool </h1>
 
-for more information：https://easy-dotnet.com/pages/easytool/
+<div align="center">
 
-| Build | NuGet |
-|--|--|
-|[![pull_request](https://github.com/786744873/easytool/actions/workflows/pull_request.yml/badge.svg)](https://github.com/786744873/easytool/actions/workflows/pull_request.yml)|[![](https://img.shields.io/nuget/v/EasyTool.Core.svg)](https://www.nuget.org/packages/EasyTool.Core)|
+一个开源的 .NET 工具库, 使得开发变得更加有效率
 
-## Api Doc
+
+[![pull_request](https://github.com/786744873/easytool/actions/workflows/pull_request.yml/badge.svg)](https://github.com/786744873/easytool/actions/workflows/pull_request.yml)
+[![](https://img.shields.io/nuget/v/EasyTool.Core.svg)](https://www.nuget.org/packages/EasyTool.Core)
+<p>
+    <span>中文</span> |  <a href="README.EN-US.md">English</a>
+</p>
+</div>
+
+## 📚 简介
+
+Easytool 是一个功能丰富且易用的 .NET 工具库，旨在帮助开发者快速、便捷地完成各类开发任务。 这些封装的工具涵盖了字符串、数字、集合、编码、日期、文件、IO、加密、JSON、HTTP客户端等一系列操作， 可以满足各种不同的开发需求。
+> [More information](https://easy-dotnet.com/pages/easytool/)
+> 
+## 🚀 快速开始
+### 安装 
+~~~
+PM> Install-Package EasyTool.Core
+~~~
+或者 .NET CLI 👇
+~~~
+dotnet add package EasyTool.Core
+~~~
+
+### 使用
+复制文件或者目录
+~~~csharp
+FileUtil.Copy(sourceDir, destinationDir, isOverwrite)
+~~~
+克隆对象
+~~~csharp
+var a = CloneUtil.Clone<Person>(person);
+~~~
+
+
+## 🛠️ 目录
+Easytool 封装了开发过程中一些常用的方法
+
+| Catalog                                           |     Introduce                                                                        |
+| --------------------------------------------------|---------------------------------------------------------------------------------- |
+| [clone](EasyTool.Core/CloneCategory/)             |     使用 CloneUtil.Clone 方法实现 .NET 对象的深度复制                                       |
+| [code](EasyTool.Core/CodeCategory/)               |     提供基于 base32, base62 等编解码工具                                             |
+
+## 代码共享
+
+
+## 社区交流
 
 **微信：ygdxg8657 （备注进群） QQ群：543829648  903210423（已满）** 
 


### PR DESCRIPTION
                        依赖于NPOI 2.6.2
			支持通过文件地址或者流的方式读取Excel文件获取工作簿对象IWorkbook,
			通过IWorkbook工作簿对象可以转化成Dataset对象
			通过ISheet工作表对象可以转化成DataTable对象和List对象
			以下是一些示例:
			获取数据集对象：
			var dateSet = NPOIUtil.OpenWorkbook(path).ConvertToDataSet();
			var dateSet = NPOIUtil.ConvertToDataSet(path);
			获取工作表对象：
			var sheet = NPOIUtil.OpenWorkbook(path).GetSheetAt(0);
			获取单表数据对象：
			var dataTable = NPOIUtil.OpenWorkbook(path).GetSheetAt(0).ConvertToDataTable();
			List《T》 dataList = NPOIUtil.OpenWorkbook(path).GetSheetAt(0).ConvertToList《List《T》》();
			从流读取工作簿对象(从流读取需要指定文件类型，缺省值为XLSX)：
			var workbook = NPOIUtil.OpenWorkbook(stream,ExcelWorkbookType.XLS);